### PR TITLE
Unify retmc server addresses with panel domain

### DIFF
--- a/jammehcow.co.nz/cloudflare.tf
+++ b/jammehcow.co.nz/cloudflare.tf
@@ -52,7 +52,7 @@ resource "cloudflare_record" "terraform_managed_resource_2e545f693a9682f1caa06b8
 }
 
 resource "cloudflare_record" "terraform_managed_resource_b0b16d7663a3427a08c6bc8bae3260b1" {
-  name    = "ret-prd.mc"
+  name    = "live.retmc"
   proxied = true
   ttl     = 1
   type    = "A"
@@ -79,7 +79,7 @@ resource "cloudflare_record" "terraform_managed_resource_6b8e1f5079e2fcc9611a1e3
 }
 
 resource "cloudflare_record" "terraform_managed_resource_1500d18916973b17ce9801b86c9def83" {
-  name    = "ret-prd.mc"
+  name    = "live.retmc"
   proxied = true
   ttl     = 1
   type    = "AAAA"

--- a/jammehcow.co.nz/cloudflare.tf
+++ b/jammehcow.co.nz/cloudflare.tf
@@ -61,7 +61,7 @@ resource "cloudflare_record" "terraform_managed_resource_b0b16d7663a3427a08c6bc8
 }
 
 resource "cloudflare_record" "terraform_managed_resource_885858db9a65132d7fb6909a3a0b188d" {
-  name    = "tst0.mc"
+  name    = "test.retmc"
   proxied = false
   ttl     = 1
   type    = "A"


### PR DESCRIPTION
This PR aims to use the same 2nd-level subdomain for retmc server nodes as the panel. This makes SSL cert management easier as it's a single subdomain with a wildcard.